### PR TITLE
fix pyproject.toml so pip install will work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cyapi"
 version = "0.9.17"
-description "Python bindings for Cylance Console"
+description="Python bindings for Cylance Console"
 
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cyapi"
 version = "0.9.17"
-description="Python bindings for Cylance Console"
+description = "Python bindings for Cylance Console"
 
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
before:
```
~> pip install "git+git@github.com:cylance/python-cyapi.git"
...
pip._vendor.toml.decoder.TomlDecodeError: Found invalid character in key name: '"'. Try quoting the key name. (line 4 column 13 char 60)
```
now it works :)