### PR TITLE
Delete Clients - Bugfix

### DIFF
--- a/cyapi/cyapi.py
+++ b/cyapi/cyapi.py
@@ -31,6 +31,7 @@ from .mixins._Exceptions import Mixin as ExceptionsMixin
 from .mixins._Focus_View import Mixin as FocusViewMixin
 from .mixins._Global_List import Mixin as GlobalListMixin
 from .mixins._InstaQueries import Mixin as InstaQueriesMixin
+from .mixins._Memory_Protection import Mixin as MemoryProtectionMixin
 from .mixins._Optics_Policies import Mixin as OpticsPoliciesMixin
 from .mixins._Packages import Mixin as PackagesMixin
 from .mixins._Policies import Mixin as PoliciesMixin
@@ -51,7 +52,7 @@ except ImportError:
 
 
 class CyAPI(DetectionsMixin,DevicesMixin,DeviceCommandsMixin,ExceptionsMixin,
-            FocusViewMixin, GlobalListMixin,InstaQueriesMixin,OpticsPoliciesMixin,
+            FocusViewMixin, GlobalListMixin,InstaQueriesMixin,MemoryProtectionMixin,OpticsPoliciesMixin,
             PackagesMixin,PoliciesMixin,RulesMixin,RulesetMixin,
             ThreatsMixin,UsersMixin,ZonesMixin):
     """The main class that should be used. Each of the Mixins above provides the

--- a/cyapi/mixins/_Devices.py
+++ b/cyapi/mixins/_Devices.py
@@ -2,14 +2,21 @@
 class Mixin:
 
     def delete_devices(self, device_ids, callback_url=None):
+        """Delete device(s) for many IDs
+        :param device_ids: must be a list of device_ids
+        """
         baseURL = self.baseURL + "devices/v2"
-
-        data = {
-            "device_ids": device_ids,
-            "callback_url": callback_url
-        }
-
-        return self._make_request("delete", baseURL, data=data)
+        if callback_url == None:
+            data = {
+                "device_ids": device_ids
+            }
+            return self._make_request("delete", baseURL, data=data)
+        else:
+            data = {
+                "device_ids": device_ids,
+                "callback_url": callback_url
+            }
+            return self._make_request("delete", baseURL, data=data)
 
     def get_devices(self, **kwargs):
         '''Get a list of Devices'''

--- a/cyapi/mixins/_Devices.py
+++ b/cyapi/mixins/_Devices.py
@@ -2,7 +2,7 @@
 class Mixin:
 
     def delete_devices(self, device_ids, callback_url=None):
-        """Delete device(s) for many IDs
+        """Delete device(s) per ID(s)
         :param device_ids: must be a list of device_ids
         """
         baseURL = self.baseURL + "devices/v2"

--- a/cyapi/mixins/_Memory_Protection.py
+++ b/cyapi/mixins/_Memory_Protection.py
@@ -1,0 +1,14 @@
+class Mixin:
+
+    def get_memory_protection_events(self, start_time=None, end_time=None, **kwargs):
+        '''Get a list of Memoryprotection Events'''
+        if end_time and not start_time:
+            raise ValueError("start_time must be set if using end_time parameter")
+        params = {"start_time": start_time, "end_time": end_time}
+
+        return self.get_list_items('memoryprotection', params=params, **kwargs)
+
+
+    def get_memory_protection_event(self, device_image_file_event_id):
+        '''Get Memoryprotection Detail'''
+        return self.get_item("memoryprotection", device_image_file_event_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cyapi"
 version = "0.9.17"
-description "Python bindings for Cylance Console"
+description = "Python bindings for Cylance Console"
 
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
This pull request solves an issue where, the default parameter "callback_url = None" doesn't work with the Cylance API.
**Screenshots of the failure:**
_with python module:_
![grafik](https://user-images.githubusercontent.com/53408989/99654693-faea1480-2a5a-11eb-9b1c-d71ff64c0274.png)
_Postman:_
![grafik](https://user-images.githubusercontent.com/53408989/99655634-3f29e480-2a5c-11eb-8ffb-49a3b979b546.png)
![grafik](https://user-images.githubusercontent.com/53408989/99655426-038f1a80-2a5c-11eb-9380-9c387b2c8085.png)

Without _callback_url_ it worked fine.
![grafik](https://user-images.githubusercontent.com/53408989/99656475-3554b100-2a5d-11eb-8551-63b7761c0c73.png)

Please review the changes before merging.