### PR TITLE
Update _Rules.py - fix URL of create_detection_rule

### DIFF
--- a/cyapi/mixins/_Rules.py
+++ b/cyapi/mixins/_Rules.py
@@ -40,7 +40,7 @@ class Mixin:
 
     def create_detection_rule(self, rule_data):
         # /rules/v2
-        baseURL = self.baseURL + "rules/v2/validate"
+        baseURL = self.baseURL + "rules/v2"
         return self._make_request("post",baseURL, data=rule_data)
 
     def update_detection_rule(self, rule_id, rule_data):


### PR DESCRIPTION
This one appears to just be a typo or oversight. The correct URL endpoint for Detection Rule creation is `/rules/v2` as noted in the comment and the documentation: https://docs.blackberry.com/content/dam/docs-blackberry-com/release-pdfs/en/cylance-products/api-and-developer-guides/Cylance%20User%20API%20Guide%20v2.0%20rev24.pdf