### PR TITLE
Bug fix for get_device_threats to remove limit=0

### DIFF
--- a/cyapi/cyapi.py
+++ b/cyapi/cyapi.py
@@ -374,7 +374,7 @@ class CyAPI(DetectionsMixin,DevicesMixin,DeviceCommandsMixin,ExceptionsMixin,
             if self.mtc:
                 baseURL = self.baseURL + "{}/{}".format(page_type,detail)
             else:
-                baseURL = self.baseURL + "{}/v2/{}".format(page_type, detail)
+                baseURL = self.baseURL + "{}/v2{}".format(page_type, detail)
                 baseURL = self._add_url_params(baseURL, q_params)
 
             response = self._make_request("get",baseURL)

--- a/cyapi/mixins/_Devices.py
+++ b/cyapi/mixins/_Devices.py
@@ -56,7 +56,7 @@ class Mixin:
         # /devices/v2/{unique_device_id}/threats?page=m&page_size=n
         detail = "/{}/threats".format(device_id)
 
-        return self.get_list_items("devices", limit=0, detail=detail, **kwargs)
+        return self.get_list_items("devices", detail=detail, **kwargs)
 
     def get_zone_devices(self, zone_id, **kwargs):
         '''Return list of devices for a given zone'''


### PR DESCRIPTION
Bug fix for get_device_threats to remove limit=0, which is not a supported value. In addition, 'limit' should have been left as an optional value to be set by user..