### PR TITLE
Added error messaging rather than an unhandled assertion error to _generate_urls…

### DIFF
--- a/cyapi/cyapi.py
+++ b/cyapi/cyapi.py
@@ -378,7 +378,16 @@ class CyAPI(DetectionsMixin,DevicesMixin,DeviceCommandsMixin,ExceptionsMixin,
                 baseURL = self._add_url_params(baseURL, q_params)
 
             response = self._make_request("get",baseURL)
-            assert response.is_success
+            try:
+                assert response.status_code == 200
+            except AssertionError:
+                print("Failed initial request for {} w/ Status Code: {}".format(page_type, response.status_code))
+                print("get URL:\n{}".format(baseURL))
+                if response.errors:
+                    print("Error(s)")
+                    for k in response.errors:
+                        print("{}: {}".format(k,response.errors.get(k)))
+                exit()
             data = response.data
 
             page_size = data['page_size']


### PR DESCRIPTION
Added error messages when assertion fails to validate successful 'get' of the initial page of a list url, before exit. As a result, these fatal errors will result in better debugging information.

For example:

> Failed initial request for threats w/ Status Code: 400

> get URL:

> https://protectapi.cylance.com/threats/v2/?page=1&page_size=200&start_time=2021-02-16T12%3A00%3A00.000Z&end_time=2021-03-22T23%3A59%3A59.000Z
> Error(s)
> message: The end time provided hasn't occured yet.