### PR TITLE
Improved error handling in _get_jwt, _get_auth_token and _generate_urls.

### DIFF
--- a/cyapi/cyapi.py
+++ b/cyapi/cyapi.py
@@ -198,13 +198,18 @@ class CyAPI(DetectionsMixin,DevicesMixin,DeviceCommandsMixin,ExceptionsMixin,
         try:
             assert resp.status_code == 200
         except AssertionError:
+            error_message = []
             try:
                 errors = resp.json()
             except json.decoder.JSONDecodeError:
                 errors = None
-            print("Failed request for JWT Token: {}".format(resp.status_code))
-            print("Description:\n{}".format(errors))
-            exit()
+            error_message.append("Failed request for JWT Token.")
+            error_message.append("  Response Status Code: {}".format(resp.status_code))
+            if not errors == None:
+                error_message.append("  Error(s):")
+                for k in errors:
+                    error_message.append("    {}: {}".format(k,errors[k]))
+            raise RuntimeError('\n'.join(error_message))
 
         data = resp.json()
         token = data.get('access_token',None)
@@ -230,13 +235,18 @@ class CyAPI(DetectionsMixin,DevicesMixin,DeviceCommandsMixin,ExceptionsMixin,
         try:
             assert resp.status_code == 200
         except AssertionError:
+            error_message = []
             try:
                 errors = resp.json()
             except json.decoder.JSONDecodeError:
                 errors = None
-            print("Failed request for MTC Auth Token: {}".format(resp.status_code))
-            print("Description:\n{}".format(errors))
-            exit()
+            error_message.append("  Failed request for MTC Auth Token")
+            error_message.append("  Response Status Code: {}".format(resp.status_code))
+            if not errors == None:
+                error_message.append("  Error(s):")
+                for k in errors:
+                    error_message.append("    {}: {}".format(k,errors[k]))
+            raise RuntimeError('\n'.join(error_message))
 
         data = resp.json()
         token = data.get('access_token',None)
@@ -381,13 +391,15 @@ class CyAPI(DetectionsMixin,DevicesMixin,DeviceCommandsMixin,ExceptionsMixin,
             try:
                 assert response.status_code == 200
             except AssertionError:
-                print("Failed initial request for {} w/ Status Code: {}".format(page_type, response.status_code))
-                print("get URL:\n{}".format(baseURL))
+                error_message = []
+                error_message.append("Failed initial request for {}.".format(page_type))
+                error_message.append("  get URL:\n    {}".format(baseURL))
+                error_message.append("  Response Status Code: {}".format(response.status_code))
                 if response.errors:
-                    print("Error(s)")
+                    error_message.append("Error(s)")
                     for k in response.errors:
-                        print("{}: {}".format(k,response.errors.get(k)))
-                exit()
+                        error_message.append("  {}: {}".format(k,response.errors.get(k)))
+                raise RuntimeError('\n'.join(error_message))
             data = response.data
 
             page_size = data['page_size']


### PR DESCRIPTION
Rather than the original assert statements, information from the response is now collected and raised with a RuntimeError. This should help w/ troubleshooting issues when using these three get requests.

Example of _get_jwt enhanced error:
`RuntimeError: Failed request for JWT Token.
  Response Status Code: 401
  Error(s):
    message: Invalid JWT payload`

Example of _generate_urls enhanced error:
`RuntimeError: Failed initial request for devices.
  get URL:
    https://protectapi.cylance.com/devices/v2//3b3d9e0c-958c-4c02-b2eb-a251191e5626/threats?page=1&page_size=0
  Response Status Code: 400
Error(s)
  message: The page size requested is not supported.`