### PR TITLE
Release to support PyJWT 2.0.0 change with backward compatibility.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyapi"
-version = "1.0.10"
+version = "1.0.20"
 description = "Python bindings for Cylance Console and MTC"
 
 license = "MIT"


### PR DESCRIPTION
A change to the release version 1.0.20, being published to pypi.